### PR TITLE
Reduce the scope of the cli improvement branch

### DIFF
--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -38,10 +38,6 @@ func NewInstallCmd() *cobra.Command {
 	installCmd.Flags().StringVar(&vars.Namespace, "namespace", "default", "The namespace where the operator watches for changes. (default to \"default\"")
 	installCmd.Flags().StringArrayVarP(&vars.Parameter, "parameter", "p", nil, "The parameter name.")
 	installCmd.Flags().StringVar(&vars.PackageVersion, "package-version", "", "A specific package version on the official GitHub repo. (default to the most recent)")
-	installCmd.Flags().StringVar(&vars.RepoName, "repo-name", "kudo-test-repo", "The storage bucket name of the repo. (default to official \"kudo-registry\")")
-	installCmd.Flags().StringVar(&vars.RepoPath, "repo-path", "", "The path of the repo. (default to \"$HOME/.kudo/repo\")")
-	// the default should be switched to our official kudo repo on GCS
-	installCmd.Flags().StringVar(&vars.RepoURL, "repo-url", "https://kudo-test-repo.storage.googleapis.com", "The url to the repo. (default to \"https://kudo-registry.storage.googleapis.com\")")
 
 	const usageFmt = "Usage:\n  %s\n\nFlags:\n%s"
 	installCmd.SetUsageFunc(func(cmd *cobra.Command) error {

--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -4,11 +4,17 @@ import (
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 )
 
-// Entry represents a collection of parameters for framework repository
-type Entry struct {
-	Name      string `json:"name"`
+// RepositoryConfiguration represents a collection of parameters for framework repository
+type RepositoryConfiguration struct {
 	LocalPath string `json:"localPath"`
 	URL       string `json:"url"`
+}
+
+func NewRepositoryConfiguration() *RepositoryConfiguration {
+	return &RepositoryConfiguration{
+		LocalPath: "$HOME/.kudo/repository", // this won't work on windows
+		URL: "https://kudo-test-repo.storage.googleapis.com",
+	}
 }
 
 // Metadata for a Framework. This models the structure of a bundle.yaml file.

--- a/pkg/kudoctl/util/repo/repo_index.go
+++ b/pkg/kudoctl/util/repo/repo_index.go
@@ -2,13 +2,10 @@ package repo
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"sort"
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"github.com/kudobuilder/kudo/pkg/version"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
@@ -75,20 +72,10 @@ func (i IndexFile) SortEntries() {
 	}
 }
 
-// LoadIndexFile takes a file at the given path and returns an IndexFile object
-func (i IndexFile) LoadIndexFile(path string) (*IndexFile, error) {
-	b, err := ioutil.ReadFile(path + "/index.yaml")
-	if err != nil {
-		return nil, err
-	}
-
-	return loadIndex(b)
-}
-
-// loadIndex loads an index file and does minimal validity checking.
+// parseIndexFile loads an index file and does minimal validity checking.
 //
 // This will fail if API Version is not set (ErrNoAPIVersion) or if the unmarshal fails.
-func loadIndex(data []byte) (*IndexFile, error) {
+func parseIndexFile(data []byte) (*IndexFile, error) {
 	i := &IndexFile{}
 	if err := yaml.Unmarshal(data, i); err != nil {
 		return i, errors.Wrap(err, "unmarshalling index file")
@@ -143,12 +130,4 @@ func (i IndexFile) Get(name, version string) (*BundleVersion, error) {
 		}
 	}
 	return nil, fmt.Errorf("no chart version found for %s-%s", name, version)
-}
-
-// Exists returns true if the index.yaml file exists on the local file system
-func (i IndexFile) Exists() bool {
-	if _, err := os.Stat(vars.RepoPath + "/index.yaml"); os.IsNotExist(err) {
-		return false
-	}
-	return true
 }

--- a/pkg/kudoctl/util/repo/repo_index.go
+++ b/pkg/kudoctl/util/repo/repo_index.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/kudobuilder/kudo/pkg/version"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 )
@@ -51,22 +50,13 @@ func (b BundleVersions) Less(x, y int) bool {
 	return i.LessThan(j)
 }
 
-// NewIndexFile initializes an index.
-func NewIndexFile() *IndexFile {
-	return &IndexFile{
-		APIVersion: version.Get().GitVersion,
-		Generated:  time.Now(),
-		Entries:    map[string]BundleVersions{},
-	}
-}
-
-// SortEntries sorts the entries by version in descending order.
+// sortPackages sorts the entries by version in descending order.
 //
 // In canonical form, the individual version records should be sorted so that
 // the most recent release for every version is in the 0th slot in the
 // Entries.BundleVersions array. That way, tooling can predict the newest
 // version without needing to parse SemVers.
-func (i IndexFile) SortEntries() {
+func (i IndexFile) sortPackages() {
 	for _, versions := range i.Entries {
 		sort.Sort(sort.Reverse(versions))
 	}
@@ -80,43 +70,37 @@ func parseIndexFile(data []byte) (*IndexFile, error) {
 	if err := yaml.Unmarshal(data, i); err != nil {
 		return i, errors.Wrap(err, "unmarshalling index file")
 	}
-	i.SortEntries()
+	i.sortPackages()
 	if i.APIVersion == "" {
 		return i, errors.New("no API version specified")
 	}
 	return i, nil
 }
 
-// Get returns the ChartVersion for the given name.
-//
-// If version is empty, this will return the chart with the highest version.
-func (i IndexFile) Get(name, version string) (*BundleVersion, error) {
+// GetByName returns the framework of given name.
+func (i IndexFile) GetByName(name string) (*BundleVersion, error) {
+	constraint, err := semver.NewConstraint("*")
+	if err != nil {
+		return nil, err
+	}
+
+	return i.getFramework(name, constraint)
+}
+
+// GetByNameAndVersion returns the framework of given name and version.
+func (i IndexFile) GetByNameAndVersion(name, version string) (*BundleVersion, error) {
+	constraint, err := semver.NewConstraint(version)
+	if err != nil {
+		return nil, err
+	}
+
+	return i.getFramework(name, constraint)
+}
+
+func (i IndexFile) getFramework(name string, versionConstraint *semver.Constraints) (*BundleVersion, error) {
 	vs, ok := i.Entries[name]
-	if !ok {
-		return nil, errors.New("no chart name found")
-	}
-	if len(vs) == 0 {
-		return nil, errors.New("no chart version found")
-	}
-
-	var constraint *semver.Constraints
-	if len(version) == 0 {
-		constraint, _ = semver.NewConstraint("*")
-	} else {
-		var err error
-		constraint, err = semver.NewConstraint(version)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// when customer input exact version, check whether have exact match one first
-	if len(version) != 0 {
-		for _, ver := range vs {
-			if version == ver.Version {
-				return ver, nil
-			}
-		}
+	if !ok || len(vs) == 0 {
+		return nil, fmt.Errorf("no framework of given name %s and version %v found", name, versionConstraint)
 	}
 
 	for _, ver := range vs {
@@ -125,9 +109,9 @@ func (i IndexFile) Get(name, version string) (*BundleVersion, error) {
 			continue
 		}
 
-		if constraint.Check(test) {
+		if versionConstraint.Check(test) {
 			return ver, nil
 		}
 	}
-	return nil, fmt.Errorf("no chart version found for %s-%s", name, version)
+	return nil, fmt.Errorf("no framework version found for %s-%v", name, versionConstraint)
 }

--- a/pkg/kudoctl/util/vars/vars.go
+++ b/pkg/kudoctl/util/vars/vars.go
@@ -11,9 +11,7 @@ var (
 	Namespace            string
 	Parameter            []string
 	PackageVersion       string
-	RepoName             string
-	RepoPath             string
-	RepoURL              string
 	StorageBucket        string
 	StoragePrefix        string
+	RepoPath 			 string = "$HOME/.kudo/repository" // this won't work on windows
 )


### PR DESCRIPTION
I've made the scope a bit smaller - if we go with repo configuration and repo command, I think we should not introduce configuration options to `install` command. I think it's ok to have default repo hardcoded for 0.2.0. It was hardcoded right now anyway as well...

Also I removed the index file caching. We can add that later it's just an optimization